### PR TITLE
Append streetNumber to "street" when needed

### DIFF
--- a/Classes/Utility/PaymentUtility.php
+++ b/Classes/Utility/PaymentUtility.php
@@ -285,7 +285,13 @@ class PaymentUtility
         $this->paymentQuery['email'] = $billingAddress->getEmail();
         $this->paymentQuery['company'] = $billingAddress->getCompany();
         $this->paymentQuery['zip'] = $billingAddress->getZip();
-        $this->paymentQuery['street'] = $billingAddress->getStreet();
+
+        if (empty($billingAddress->getStreetNumber())) {
+            $this->paymentQuery['street'] = $billingAddress->getStreet();
+        } else {
+            $this->paymentQuery['street'] = $billingAddress->getStreet() . " " . $billingAddress->getStreetNumber();
+        }
+
         $this->paymentQuery['city'] = $billingAddress->getCity();
         $this->paymentQuery['country'] = strtoupper($billingAddress->getCountry());
     }


### PR DESCRIPTION
Cart can be configured to have an additional StreetNumber input field. In case its not empty it should be appended to the street input itself. PayOne itself will throw an error in their submit form when no streetnumber is inside the street string, also its an important data for the correct payment information.